### PR TITLE
`listingsutf8` compatability

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
@@ -14,8 +14,10 @@ they all do the same thing, i.\,e.\ displaying listings with or without typesett
 the listing in \LaTeX\ parallel.
 The difference is the underlying \LaTeX\ package which does the core job for
 displaying a listing. So, typically, you need just \emph{one} of these
-libraries. If you do not have a clue, which one of them you should use,
-you should take \mylib{listingsutf8}.
+libraries. If you do not have a clue which one of them you should use
+and you are using |pdflatex|, you should take \mylib{listingsutf8}.
+If you are using |xelatex| or |lualatex|, you should take \mylib{listings}
+as |xelatex| and |lualatex| are not compatible with \mylib{listingsutf8}.
 
 \begin{marker}
 The order in which the libraries are included influences the default settings and

--- a/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
@@ -40,7 +40,7 @@ To reactivate this setting, if overwritten by other libraries, use
 
 \subsubsection{Loading \mylib{listingsutf8}}
 \begin{marker}
-This library is not needed (and troublesome) when using Xe\LaTeX.
+This library is not needed (and troublesome) when using Xe\LaTeX\ or Lua\LaTeX.
 \end{marker}
 To extend |listings| for UTF-8 encoded sources, you can use the support from
 the package |listingsutf8| \cite{oberdiek:2011a} by loading the library
@@ -422,7 +422,7 @@ For an combined example of using |\lstinline| inside a |tcolorbox|, see
 \clearpage
 \subsection{Option Keys of the \mylib{listingsutf8} Library}
 \begin{marker}
-The \mylib{listingsutf8} library is not needed (and troublesome) when using Xe\LaTeX.
+The \mylib{listingsutf8} library is not needed (and troublesome) when using Xe\LaTeX\ or Lua\LaTeX.
 \end{marker}
 
 The \mylib{listingsutf8} library is an extension of the


### PR DESCRIPTION
I'm not sure of your preferred way to send patches, so if you prefer something other than pull requests, let me know.

This pull request contains documentation clarifications relating to issue #56.  These changes are based on `v4.12` as that is the version of the documentation that builds on my system.  However, they should work fine against the current head.

The first commit modifies the warnings about using XeLaTeX with `listingsutf8` to also warn about about using LuaLaTeX.

The second commit modifies the recommendation to use `listingsutf8` to recommend it only when using `pdflatex`.  This helps users like I was who stop reading at that point and thus would not see the later warnings.