### PR TITLE
Using group around arguments for title in the examples

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox.doc.coremacros.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.coremacros.tex
@@ -173,7 +173,7 @@ This is my own box.
 \begin{dispExample*}{sbs,lefthand ratio=0.6}
 \newtcolorbox{mybox}[1]{colback=red!5!white,
   colframe=red!75!black,fonttitle=\bfseries,
-  title=#1}
+  title={#1}}
 
 \begin{mybox}{Hello there}
 This is my own box with a mandatory title.
@@ -185,7 +185,7 @@ This is my own box with a mandatory title.
   colframe=red!75!black,fonttitle=\bfseries,
   colbacktitle=red!85!black,enhanced,
 attach boxed title to top center={yshift=-2mm},
-  title=#2,#1}
+  title={#2},#1}
 
 \begin{mybox}[colback=yellow]{Hello there}
 This is my own box with a mandatory title
@@ -229,7 +229,7 @@ numbered title and options.
 \begin{dispExample*}{sbs,lefthand ratio=0.6}
 \newtcbox{\mybox}[1]{colback=red!5!white,
   colframe=red!75!black,fonttitle=\bfseries,
-  title=#1}
+  title={#1}}
 
 \mybox{Hello there}{This is my own box.}
 \end{dispExample*}
@@ -237,7 +237,7 @@ numbered title and options.
 \begin{dispExample*}{sbs,lefthand ratio=0.6}
 \newtcbox{\mybox}[2][]{colback=red!5!white,
   colframe=red!75!black,fonttitle=\bfseries,
-  title=#2,#1}
+  title={#2},#1}
 
 \mybox[colback=yellow]{Hello there}%
   {This is my own box.}

--- a/doc/latex/tcolorbox/tcolorbox.doc.coreoptions.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.coreoptions.tex
@@ -409,7 +409,7 @@ This is the lower part.
   \tcolorbox[savedelimiter=mybox,
              savelowerto=\jobname_bspsave2.tex,lowerbox=ignored,
              colback=red!5!white,colframe=red!75!black,fonttitle=\bfseries,
-             title=#1]}%
+             title={#1}]}%
   {\endtcolorbox}
 
 \begin{mybox}{My Example}
@@ -432,7 +432,7 @@ allows a more convenient usage:
 \newtcolorbox{mybox}[1]{%
              savelowerto=\jobname_bspsave2.tex,lowerbox=ignored,
              colback=red!5!white,colframe=red!75!black,fonttitle=\bfseries,
-             title=#1}%
+             title={#1}}%
 
 \begin{mybox}{My Example}
 Upper part.

--- a/doc/latex/tcolorbox/tcolorbox.doc.fitting.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.fitting.tex
@@ -497,7 +497,7 @@ are adapted. In the following, adapting the font size means adapting
   bottom=1mm,right=1mm,boxsep=0mm,width=3.5cm,height=7cm,nobeforeafter,
   before upper=\textcolor{blue}{\rule{5mm}{5mm}}\ ,
   enhanced,watermark text={\tcbfitsteps},
-  fonttitle=\bfseries,adjusted title=#1,fit algorithm=#1}
+  fonttitle=\bfseries,adjusted title={#1},fit algorithm=#1}
 
 \mybox{fontsize}{\lipsum[2]}\hfill
 \mybox{hybrid}{\lipsum[2]}\hfill
@@ -513,7 +513,7 @@ Quality \dotfill versus \dotfill Speed
 \newtcboxfit{mybox}[2]{colback=red!5!white,colframe=red!75!black,left=1mm,top=1mm,
   size=tight,width=7.2cm,height=5cm,nobeforeafter,
   before upper=\textcolor{blue}{\rule{5mm}{5mm}}\ ,
-  enhanced,fonttitle=\bfseries,adjusted title=#2,fit algorithm=#1}
+  enhanced,fonttitle=\bfseries,adjusted title={#2},fit algorithm=#1}
 
 \mybox{hybrid}{hybrid (possible gap at end)}{\lipsum[1]}\hfill
 \mybox{hybrid*}{hybrid* (no gap but possibly squeezed)}{\lipsum[1]}

--- a/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
@@ -234,7 +234,7 @@ This is my \LaTeX\ box.
   colback=red!5!white,
   colframe=red!75!black,
   fonttitle=\bfseries,
-  title=#1}
+  title={#1}}
 
 \begin{mybox}{Listing Box}
 This is my \LaTeX\ box.
@@ -246,7 +246,7 @@ This is my \LaTeX\ box.
   colback=red!5!white,
   colframe=red!75!black,
   fonttitle=\bfseries,
-  title=#2,#1}
+  title={#2},#1}
 
 \begin{mybox}[listing only]
   {Listing Box}

--- a/doc/latex/tcolorbox/tcolorbox.doc.skins.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.skins.tex
@@ -4090,7 +4090,7 @@ This box looks like a box provided by the \texttt{beamer} class.
 
 \begin{dispExample}
 \newtcolorbox{myblock}[2][]{%
-  beamer,breakable,colback=LightBlue,colframe=DarkBlue,#1,title=#2}%
+  beamer,breakable,colback=LightBlue,colframe=DarkBlue,#1,title={#2}}%
 
 \begin{myblock}{Beamerish \texttt{block}: \texttt{myblock}}
 \lipsum[1]

--- a/doc/latex/tcolorbox/tcolorbox.doc.xparse.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.xparse.tex
@@ -412,7 +412,7 @@ Besides \mylib{xparse}, the following commands also need the \mylib{listings} li
   IfBooleanTF={#1}
     {listing side text}
     {text side listing},
-  title=#3,#2}
+  title={#3},#2}
 
 \begin{mybox}{Listing Box}
 This is my


### PR DESCRIPTION
The syntax `title=#1` is perfectly valid for the examples in the manual, but in praxis this frequently leads to problems if users have special characters like `=` or `,` in their titles.

What is more problematic is that this seems to be very hard to diagnose for the users. A couple of example for the past few weeks:

- user had `=` in their title, they asked on a Q&A site why math would not be allowed in the title

- user had `,` in their title, they asked why greek letters cause problems 
