### PR TITLE
fix typo in `\RenewTCBox` definition

### DIFF
--- a/tex/latex/tcolorbox/tcolorbox.sty
+++ b/tex/latex/tcolorbox/tcolorbox.sty
@@ -2314,7 +2314,7 @@
   }
 \NewDocumentCommand \RenewTotalTCBox { }
   {
-    \__tcobox_new_TotalTCBox:w \RewewDocumentCommand
+    \__tcobox_new_TotalTCBox:w \RenewDocumentCommand
   }
 \NewDocumentCommand \ProvideTotalTCBox { }
   {

--- a/tex/latex/tcolorbox/tcolorbox.sty
+++ b/tex/latex/tcolorbox/tcolorbox.sty
@@ -2286,7 +2286,7 @@
   }
 \NewDocumentCommand \RenewTCBox { }
   {
-    \__tcobox_new_TCBox:w \RewewDocumentCommand
+    \__tcobox_new_TCBox:w \RenewDocumentCommand
   }
 \NewDocumentCommand \ProvideTCBox { }
   {


### PR DESCRIPTION
Fixes typo `\RewewDocumentCommand` to `\RenewDocumentCommand` in definitions of `\RenewTCBox` and `\RenewTotalTCBox`.