### PR TITLE
Replacing "\tikzname\ " by TikZ in a comment line

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox.doc.coremacros.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.coremacros.tex
@@ -141,7 +141,7 @@ Text \tcbox[tcbox raise base]{Hello World}\hfill
 % Fitted width box (like hbox or makebox)
 \tcbox{Hello\\World!}
 
-% Fitted width box (using a \tikzname\  node)
+% Fitted width box (using a TikZ node)
 \tcbox[tikznode]{Hello\\World!}
 \end{dispExample}
 


### PR DESCRIPTION
As the code is typeset verbatim (all in italic after the % sign), the \tikzname is not rendered as "Ti*k*Z", but as "\tikzname". So I suggest replacing \tikzname by TikZ in comments of code. See page 14 of the current documentation the listing of the code: we read "\tikzname" in the comment, not "TikZ".