### PR TITLE
Protect/Brace arguments delimited by square brackets

### DIFF
--- a/doc/latex/tcolorbox/CHANGES.md
+++ b/doc/latex/tcolorbox/CHANGES.md
@@ -11,6 +11,8 @@ and this project adheres to
 ### Added
 
 ### Changed
+- Added braces to protect square brackets, mostly for key values
+  (issue #229, continued)
 
 ### Deprecated
 

--- a/tex/latex/tcolorbox/tcbdocumentation.code.tex
+++ b/tex/latex/tcolorbox/tcbdocumentation.code.tex
@@ -150,7 +150,7 @@
   index colorize/.is if=tcb@doc@colorize,%
   index annotate/.is if=tcb@doc@annotate,%
   index command/.code={\def\kvtcb@index@command##1{#1{##1}}},%
-  index command name/.code={\def\kvtcb@index@command##1{\index[#1]{##1}}},%
+  index command name/.code={\def\kvtcb@index@command##1{\index[{#1}]{##1}}},%
   doc left/.dimstore in=\kvtcb@doc@left,
   doc right/.dimstore in=\kvtcb@doc@right,
   doc left indent/.dimstore in=\kvtcb@doc@indentleft,
@@ -868,7 +868,7 @@
 
 \setrefcountdefault{-1}
 \NewDocumentCommand\tcb@ref@doc{msm}{%
-  \hyperref[#1:#3]{\texttt{\ref*{#1:#3}}%
+  \hyperref[{#1:#3}]{\texttt{\ref*{#1:#3}}%
   \IfBooleanTF{#2}{}{%
     \ifnum\getpagerefnumber{#1:#3}=\thepage\relax%
     \else%
@@ -899,12 +899,12 @@
 
 \newcommand{\tcbdocmarginnote}[2][]{%
   \marginnote{%
-  \begin{tcolorbox}[enhanced jigsaw,size=fbox,boxrule=1pt,leftrule=0pt,rightrule=0pt,
+  \begin{tcolorbox}[{enhanced jigsaw,size=fbox,boxrule=1pt,leftrule=0pt,rightrule=0pt,
     arc=0pt,outer arc=1pt,boxsep=1pt,top=1pt,bottom=1pt,
     nobeforeafter,width=\marginparwidth,
     colframe=red!50!white,colback=red!25!yellow!5!white,fontupper=\scriptsize,
     if odd page or oneside={flushright upper}{flushleft upper},
-    doc@marginnote,#1]#2\end{tcolorbox}}}
+    doc@marginnote,#1}]#2\end{tcolorbox}}}
 
 \newcommand*{\tcbdocnew}[1]{\kvtcb@text@new: #1}
 \newcommand*{\tcbdocupdated}[1]{\kvtcb@text@updated: #1}

--- a/tex/latex/tcolorbox/tcbexternal.code.tex
+++ b/tex/latex/tcolorbox/tcbexternal.code.tex
@@ -160,7 +160,7 @@
   \tcb@newenvironment{#1}[2][]{%
     #4%
     \begingroup%
-    \tcbexternal[#3,##1,environment=#2]{##2}%
+    \tcbexternal[{#3,##1,environment=#2}]{##2}%
   }{%
     \endtcbexternal%
     \endgroup%

--- a/tex/latex/tcolorbox/tcbfitting.code.tex
+++ b/tex/latex/tcolorbox/tcbfitting.code.tex
@@ -380,15 +380,15 @@
     \__tcobox_process_newtcolorbox:nn { #2 }{ #3 }
     \tl_if_novalue:nTF { #4 }
       {
-        \exp_args:Nc #1 { #3 }{ \tcboxfit[#6,options@for=#3] }
+        \exp_args:Nc #1 { #3 }{ \tcboxfit[{#6,options@for=#3}] }
       }
       {
         \tl_if_novalue:nTF { #5 }
         {
-          \exp_args:Nc #1 { #3 }[ #4 ]{ \tcboxfit[#6,options@for=#3] }
+          \exp_args:Nc #1 { #3 }[ #4 ]{ \tcboxfit[{#6,options@for=#3}] }
         }
         {
-          \exp_args:Nc #1 { #3 }[ #4 ][ #5 ]{ \tcboxfit[#6,options@for=#3] }
+          \exp_args:Nc #1 { #3 }[ #4 ][ #5 ]{ \tcboxfit[{#6,options@for=#3}] }
         }
       }
   }

--- a/tex/latex/tcolorbox/tcbposter.code.tex
+++ b/tex/latex/tcolorbox/tcbposter.code.tex
@@ -131,9 +131,9 @@
   \tcbdimto\tcb@poster@boxwidth{\tcb@poster@span\dimexpr\tcbpostercolwidth+\tcbpostercolspacing\relax-\tcbpostercolspacing}%
   \iftcb@posterbox@sequence%
     \begin{pgfinterruptpicture}%
-      \begin{tcolorbox}[tcb@poster@style,width=\tcb@poster@boxwidth,tcb@poster@boxheight,
+      \begin{tcolorbox}[{tcb@poster@style,width=\tcb@poster@boxwidth,tcb@poster@boxheight,
         height fixed for=all,#1,
-        enforce breakable,reset box array=tcb@poster,store to box array=tcb@poster]#3\end{tcolorbox}%
+        enforce breakable,reset box array=tcb@poster,store to box array=tcb@poster}]#3\end{tcolorbox}%
     \end{pgfinterruptpicture}%
     \def\tcb@poster@boxcount{0}%
     \renewcommand*{\do}[1]{\edef\tcb@poster@boxcount{\the\numexpr\tcb@poster@boxcount+1\relax}%
@@ -153,8 +153,8 @@
     \fi%
   \else%
     \begin{pgfinterruptpicture}%
-      \begin{tcolorbox}[tcb@poster@style,width=\tcb@poster@boxwidth,tcb@poster@boxheight,#1,
-        reset box array=tcb@poster,store to box array=tcb@poster]#3\end{tcolorbox}%
+      \begin{tcolorbox}[{tcb@poster@style,width=\tcb@poster@boxwidth,tcb@poster@boxheight,#1,
+        reset box array=tcb@poster,store to box array=tcb@poster}]#3\end{tcolorbox}%
     \end{pgfinterruptpicture}%
     \node[inner sep=0pt,outer sep=0,tcb@poster@node,name=\tcb@poster@prefix\tcb@poster@boxname] at (\tcb@poster@xpos|-\tcb@poster@ypos)
       {\consumeboxarray[tcb@poster]{1}};%
@@ -166,7 +166,7 @@
 }
 
 \newenvironment{tcb@poster@boxenv}[2][]{%
-  \newcommand{\tcb@poster@box@saved}{\posterbox[#1]{#2}{\tcbusetemp}}%
+  \newcommand{\tcb@poster@box@saved}{\posterbox[{#1}]{#2}{\tcbusetemp}}%
   \tcbwritetemp}%
   {\endtcbwritetemp\tcb@poster@box@saved}
 

--- a/tex/latex/tcolorbox/tcbraster.code.tex
+++ b/tex/latex/tcolorbox/tcbraster.code.tex
@@ -229,24 +229,24 @@
 }
 
 \newcommand{\tcbitem@following}[1][]{%
-  \end{tcolorbox}\begin{tcolorbox}[#1]%
+  \end{tcolorbox}\begin{tcolorbox}[{#1}]%
 }
 
 \newcommand{\tcbitem@first}[1][]{%
   \let\tcbitem=\tcbitem@following%
-  \begin{tcolorbox}[#1]%
+  \begin{tcolorbox}[{#1}]%
 }
 
 \newenvironment{tcbitemize}[1][]{%
-  \begin{tcbraster}[#1]%
+  \begin{tcbraster}[{#1}]%
   \let\tcb@raster@change@fitbox=\tcb@raster@change@hbox%
   \let\tcbitem=\tcbitem@first%
 }{\end{tcolorbox}\end{tcbraster}}
 
 \newenvironment{tcboxedraster}[2][]{%
-  \tcolorbox[{#2}]\begin{tcbraster}[#1]}%
+  \tcolorbox[{#2}]\begin{tcbraster}[{#1}]}%
   {\end{tcbraster}\endtcolorbox}
 
 \newenvironment{tcboxeditemize}[2][]{%
-  \tcolorbox[{#2}]\tcbitemize[#1]}%
+  \tcolorbox[{#2}]\tcbitemize[{#1}]}%
   {\endtcbitemize\endtcolorbox}

--- a/tex/latex/tcolorbox/tcbskins.code.tex
+++ b/tex/latex/tcolorbox/tcbskins.code.tex
@@ -1899,7 +1899,7 @@
 }\fi}
 
 \tcbset{%
-  hyperref node/.style 2 args={finish={\tcbhypernode{\hyperref[#1]}{#2}}},
+  hyperref node/.style 2 args={finish={\tcbhypernode{\hyperref[{#1}]}{#2}}},
   hyperref/.style={hyperref node={#1}{frame}},
   hyperref interior/.style={hyperref node={#1}{interior}},
   hyperref title/.style={hyperref node={#1}{title}},
@@ -1911,7 +1911,7 @@
   hyperurl/.style={hyperurl node={#1}{frame}},
   hyperurl interior/.style={hyperurl node={#1}{interior}},
   hyperurl title/.style={hyperurl node={#1}{title}},
-  hyperurl* node/.style n args={3}{finish={\tcbhypernode{\href[#1]{#2}}{#3}}},
+  hyperurl* node/.style n args={3}{finish={\tcbhypernode{\href[{#1}]{#2}}{#3}}},
   hyperurl*/.style 2 args={hyperurl* node={#1}{#2}{frame}},
   hyperurl* interior/.style 2 args={hyperurl* node={#1}{#2}{interior}},
   hyperurl* title/.style 2 args={hyperurl* node={#1}{#2}{title}},

--- a/tex/latex/tcolorbox/tcbtheorems.code.tex
+++ b/tex/latex/tcolorbox/tcbtheorems.code.tex
@@ -149,7 +149,7 @@
 
 \NewDocumentCommand \__tcobox_new_tcbtheorem_x:w { m O{} m m +m m }
   {
-    #1 [auto~counter,#2] {#3} { +O{} +o +m m }
+    #1 [{auto~counter,#2}] {#3} { +O{} +o +m m }
       {
         #5,
         title      = {\__tcobox_theo_title:nnn{#4}{\thetcbcounter}{##3}},
@@ -165,7 +165,7 @@
         theo@label = {#6}{##4},
         ##1
       }
-    #1 [#2,no~counter,list~inside=] {#3*} { +O{} +m }
+    #1 [{#2,no~counter,list~inside=}] {#3*} { +O{} +m }
       {
         #5,
         title = {\__tcobox_theo_title:nnn{#4}{}{##2}},

--- a/tex/latex/tcolorbox/tcolorbox.sty
+++ b/tex/latex/tcolorbox/tcolorbox.sty
@@ -808,11 +808,11 @@
   hypertarget/.style={phantom={\ifdefined\hypertarget\Hy@raisedlink{\hypertarget{#1}{}}\fi}},
   bookmark*/.style 2 args={phantom={\ifdefined\bookmark%
     \Hy@raisedlink{\hypertarget{tcb@\thetcolorboxnumber}{}}%
-    \bookmark[dest=tcb@\thetcolorboxnumber,rellevel=1,keeplevel,#1]{#2}%
+    \bookmark[{dest=tcb@\thetcolorboxnumber,rellevel=1,keeplevel,#1}]{#2}%
     \fi}},
   bookmark/.style={bookmark*={}{#1}},
   index/.style={phantom={\index{#1}}},%
-  index*/.style 2 args={phantom={\index[#1]{#2}}},%
+  index*/.style 2 args={phantom={\index[{#1}]{#2}}},%
   add to list/.style 2 args={phantom={\tcb@addcontentsline{#1}{#2}}},
   nophantom/.code={\def\kvtcb@phantom{}},%
   shield externalize/.is choice,
@@ -2089,14 +2089,14 @@
   \let\tcb@trans@bottom\kvtcb@bottomtitle%
   \let\tcb@trans@rule\kvtcb@title@rule%
   \let\tcb@trans@style\kvtcb@subtitle@style%
-  \begin{tcolorbox}[sharp corners,
+  \begin{tcolorbox}[{sharp corners,
     before skip={0.5\baselineskip},after skip={0.5\baselineskip},
     colframe=tcbtranscol@frame,colback=tcbtranscol@back,
     colupper=tcbtranscol@upper,fontupper=\tcb@trans@fontupper,
     boxsep=\tcb@trans@boxsep,left=\tcb@trans@left,right=\tcb@trans@right,
     top=\tcb@trans@top,bottom=\tcb@trans@bottom,
     boxrule=\tcb@trans@rule,leftrule=\z@,rightrule=\z@,oversize,
-    code={\pgfkeysalsofrom\tcb@trans@style},#1]%
+    code={\pgfkeysalsofrom\tcb@trans@style},#1}]%
   #2%
   \end{tcolorbox}%
   \endgroup%
@@ -2497,7 +2497,7 @@
             #1{#4}
           }
           {
-            #1[#3]{#4}
+            #1[{#3}]{#4}
           }
       }
     \@starttoc{#2}


### PR DESCRIPTION
This PR is just for showing the long diff more conveniently. It can be safely closed without merging.

I checked every occurrence of `[` in files in `./tex` subdirectory, and apart from `tikz`-level use cases, theses are the ones I think/assume need to be protected. For all the braces added, I admit they are not equally necessary. The two most helpful cases are for `\tcblistof` and `\tcbsubtitle`.

Part of #229

```tex
\documentclass{article}
\usepackage{tcolorbox}

\begin{document}
\tableofcontents
\tcblistof[\section]{exam}[{LoE, Short title[]}]{List of Exercises}

\begin{tcolorbox}[title=Title, after title={[]}]
  content
  \tcbsubtitle[{after upper=[]}]{Subtitle}
  content
\end{tcolorbox}
\end{document}
```

| Before | After |
|--------|--------|
| ![image](https://github.com/T-F-S/tcolorbox/assets/6376638/cd6c429f-664f-4061-9f0d-58dc7a1b3edd) | ![image](https://github.com/T-F-S/tcolorbox/assets/6376638/7cf1624c-f1c4-4442-b8db-f8e4ab4bd902) |