### PR TITLE
change mention of tikz to tikzfill.image in skins description

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox.doc.intro.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.intro.tex
@@ -81,8 +81,9 @@ The following keys are used inside |\tcbuselibrary| respectively
 |\usepackage| without the key tree path |/tcb/library/|.
 
 \begin{docTcbKey}[library]{skins}{}{\mylib{skins}}
-  Provides additional styles (skins) for the appearance of the colored boxes;
-  see Section~\ref{sec:skins} from page~\pageref{sec:skins}.
+  Loads the package \refPkg[tikzfill]{tikzfill.image} and provides
+  additional styles (skins) for the appearance of the colored boxes; see
+  Section~\ref{sec:skins} from page~\pageref{sec:skins}.
 \end{docTcbKey}
 
 \begin{docTcbKey}[library]{vignette}{}{\mylib{vignette}}

--- a/doc/latex/tcolorbox/tcolorbox.doc.intro.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.intro.tex
@@ -81,9 +81,8 @@ The following keys are used inside |\tcbuselibrary| respectively
 |\usepackage| without the key tree path |/tcb/library/|.
 
 \begin{docTcbKey}[library]{skins}{}{\mylib{skins}}
-  Loads the package \refPkg{tikz} \cite{tantau:tikz_and_pgf} and provides additional
-  styles (skins) for the appearance of the colored boxes; see
-  Section~\ref{sec:skins} from page~\pageref{sec:skins}.
+  Provides additional styles (skins) for the appearance of the colored boxes;
+  see Section~\ref{sec:skins} from page~\pageref{sec:skins}.
 \end{docTcbKey}
 
 \begin{docTcbKey}[library]{vignette}{}{\mylib{vignette}}


### PR DESCRIPTION
The package always loads tikz now, and skins loads tikzfill.image, so I just replaced the mention of tikz with tikzfill.image.