### PR TITLE
library 'skins': new options 'alt' and 'temporal' for the use with beamer

### DIFF
--- a/doc/latex/tcolorbox/CHANGELOG.md
+++ b/doc/latex/tcolorbox/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - library 'skins':
   - options 'alt' and 'temporal' for the use with beamer
+- library 'documentation':
+  - macro `\ssarg` to document beamer overlay specifications
 
 ### Changed
 

--- a/doc/latex/tcolorbox/CHANGELOG.md
+++ b/doc/latex/tcolorbox/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 ### Added
 
+- library 'skins':
+  - options 'alt' and 'temporal' for the use with beamer
+
 ### Changed
 
 ### Deprecated

--- a/doc/latex/tcolorbox/tcolorbox.doc.beamer.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.beamer.tex
@@ -72,16 +72,12 @@ The option \refKey{/tcb/only} belonged to the base package before version 4.20.
 \end{marker}
 \end{docTcbKey}
 
-\begin{docTcbKey}[][doc new={2025-05-25}]{alt}{=\textless\meta{overlay specification}\textgreater\marg{default options}\marg{alternative options}}{}
-\hfill (style, no default, initially unset)
-
+\begin{docTcbKey}[][doc new={2025-05-25},doc head key={sidebyside align=bottom}]{alt}{=\textless\meta{overlay specification}\textgreater\marg{default options}\marg{alternative options}\\}{style, no default, initially unset}
 Alternates between different |tcolorbox| \meta{options} in dependency of a |beamer| \meta{overlay specification}.
 Note that this needs the |beamer| class \cite{tantau:beamer}.
 \end{docTcbKey}
 
-\begin{docTcbKey}[][doc new={2025-05-25}]{temporal}{=\textless\meta{overlay specification}\textgreater\marg{before slide options}\marg{default options}\marg{after slide options}}{}
-\hfill (style, no default, initially unset)
-
+\begin{docTcbKey}[][doc new={2025-05-25},doc head key={sidebyside align=bottom}]{temporal}{=\textless\meta{overlay specification}\textgreater\marg{before slide options}\marg{default options}\marg{after slide options}}{style, no default, initially unset}
 Temporarily changes between different |tcolorbox| \meta{options} in dependency of a |beamer| \meta{overlay specification}.
 Note that this needs the |beamer| class \cite{tantau:beamer}.
 \end{docTcbKey}

--- a/doc/latex/tcolorbox/tcolorbox.doc.beamer.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.beamer.tex
@@ -13,7 +13,7 @@ by a package option or inside the preamble by:
 
 See \Vref{sec:skins} for the documentation of all other options of the \mylib{skins} library.
 
-\begin{docTcbKey}[][doc new and updated={2015-01-09}{2019-03-01}]{only}{=\textless\meta{overlay specification}\textgreater\marg{options}}{style, no default, initially unset}
+\begin{docTcbKey}[][doc new and updated={2015-01-09}{2019-03-01}]{only}{=\ssarg{overlay specification}\marg{options}}{style, no default, initially unset}
 Sets the given |tcolorbox| \meta{options} in dependency of
 a |beamer| \meta{overlay specification}.
 Note that this needs the |beamer| class \cite{tantau:beamer}.
@@ -72,17 +72,17 @@ The option \refKey{/tcb/only} belonged to the base package before version 4.20.
 \end{marker}
 \end{docTcbKey}
 
-\begin{docTcbKey}[][doc new={2025-05-25},doc head key={sidebyside align=bottom}]{alt}{=\textless\meta{overlay specification}\textgreater\marg{default options}\marg{alternative options}\\}{style, no default, initially unset}
+\begin{docTcbKey}[][doc new={2025-05-25},doc head key={sidebyside align=bottom}]{alt}{=\ssarg{overlay specification}\marg{default options}\marg{alternative options}\\}{style, no default, initially unset}
 Alternates between different |tcolorbox| \meta{options} in dependency of a |beamer| \meta{overlay specification}.
 Note that this needs the |beamer| class \cite{tantau:beamer}.
 \end{docTcbKey}
 
-\begin{docTcbKey}[][doc new={2025-05-25},doc head key={sidebyside align=bottom}]{temporal}{=\textless\meta{overlay specification}\textgreater\marg{before slide options}\marg{default options}\marg{after slide options}}{style, no default, initially unset}
+\begin{docTcbKey}[][doc new={2025-05-25},doc head key={sidebyside align=bottom}]{temporal}{=\ssarg{overlay specification}\marg{before slide options}\marg{default options}\marg{after slide options}}{style, no default, initially unset}
 Temporarily changes between different |tcolorbox| \meta{options} in dependency of a |beamer| \meta{overlay specification}.
 Note that this needs the |beamer| class \cite{tantau:beamer}.
 \end{docTcbKey}
 
-\begin{docTcbKey}[][doc new={2019-03-01}]{hide}{=\textless\meta{overlay specification}\textgreater}{style, no default, initially unset}
+\begin{docTcbKey}[][doc new={2019-03-01}]{hide}{=\ssarg{overlay specification}}{style, no default, initially unset}
 Sets the \refKey{/tcb/beamer hidden} style in dependency of
 a |beamer| \meta{overlay specification}.
 \refKey{/tcb/beamer hidden} can be redefined for customization.
@@ -98,7 +98,7 @@ This style is not intended to be used directly, but in concealed way by applying
 \end{dispListing}
 \end{docTcbKey}
 
-\begin{docTcbKey}[][doc new={2019-03-01}]{alert}{=\textless\meta{overlay specification}\textgreater}{style, no default, initially unset}
+\begin{docTcbKey}[][doc new={2019-03-01}]{alert}{=\ssarg{overlay specification}}{style, no default, initially unset}
 Sets the \refKey{/tcb/beamer alerted} style in dependency of
 a |beamer| \meta{overlay specification}.
 \refKey{/tcb/beamer alerted} can be redefined for customization.

--- a/doc/latex/tcolorbox/tcolorbox.doc.beamer.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.beamer.tex
@@ -72,14 +72,25 @@ The option \refKey{/tcb/only} belonged to the base package before version 4.20.
 \end{marker}
 \end{docTcbKey}
 
+\begin{docTcbKey}[][doc new={2025-05-25}]{alt}{=\textless\meta{overlay specification}\textgreater\marg{default options}\marg{alternative options}}{}
+\hfill (style, no default, initially unset)
 
+Alternates between different |tcolorbox| \meta{options} in dependency of a |beamer| \meta{overlay specification}.
+Note that this needs the |beamer| class \cite{tantau:beamer}.
+\end{docTcbKey}
+
+\begin{docTcbKey}[][doc new={2025-05-25}]{temporal}{=\textless\meta{overlay specification}\textgreater\marg{before slide options}\marg{default options}\marg{after slide options}}{}
+\hfill (style, no default, initially unset)
+
+Temporarily changes between different |tcolorbox| \meta{options} in dependency of a |beamer| \meta{overlay specification}.
+Note that this needs the |beamer| class \cite{tantau:beamer}.
+\end{docTcbKey}
 
 \begin{docTcbKey}[][doc new={2019-03-01}]{hide}{=\textless\meta{overlay specification}\textgreater}{style, no default, initially unset}
 Sets the \refKey{/tcb/beamer hidden} style in dependency of
 a |beamer| \meta{overlay specification}.
 \refKey{/tcb/beamer hidden} can be redefined for customization.
 \end{docTcbKey}
-
 
 \begin{docTcbKey}[][doc new={2019-03-01}]{beamer hidden}{}{style, no options, initially |nirvana|}
 This style is not intended to be used directly, but in concealed way by applying
@@ -90,8 +101,6 @@ This style is not intended to be used directly, but in concealed way by applying
 }
 \end{dispListing}
 \end{docTcbKey}
-
-\clearpage
 
 \begin{docTcbKey}[][doc new={2019-03-01}]{alert}{=\textless\meta{overlay specification}\textgreater}{style, no default, initially unset}
 Sets the \refKey{/tcb/beamer alerted} style in dependency of

--- a/tex/latex/tcolorbox/tcbdocumentation.code.tex
+++ b/tex/latex/tcolorbox/tcbdocumentation.code.tex
@@ -94,6 +94,7 @@
   \colOpt{{\ttfamily[}\meta{#1}{\ttfamily]}}}
 \def\sarg{\colOpt{\ttfamily*}}
 \def\brackets#1{{\ttfamily\char`\{}#1{\ttfamily\char`\}}}
+\def\ssarg#1{{\ttfamily\char`\<}\meta{#1}{\ttfamily\char`\>}}% copied from https://github.com/josephwright/beamer/blob/97ecf0ab14b80befddde829e103aaf7df5567250/doc/beamerug-macros.tex#L193
 
 \newif\iftcb@doc@colorize
 \newif\iftcb@doc@annotate

--- a/tex/latex/tcolorbox/tcbskins.code.tex
+++ b/tex/latex/tcolorbox/tcbskins.code.tex
@@ -1911,6 +1911,8 @@
   beamer hidden/.style={nirvana},
   beamer alerted/.style={fuzzy halo},
   only/.code args={<#1>#2}{\only<#1>{\tcbset{#2}}},%
+  alt/.code args={<#1>#2#3}{\alt<#1>{\tcbset{#2}}{\tcbset{#3}}},%
+  temporal/.code args={<#1>#2#3#4}{\temporal<#1>{\tcbset{#2}}{\tcbset{#3}}{\tcbset{#4}}},%
   hide/.code args={<#1>}{\only<#1>{\tcbset{beamer hidden}}},%
   alert/.code args={<#1>}{\only<#1>{\tcbset{beamer alerted}}},%
 }


### PR DESCRIPTION
Together with the already existing `only` option, this gives the users the full power of beamer overlays. 

This way, one can for example specify on which overlays the tcolorbox should be visible instead of specifying on which it should *not* be visible, which is usually the way beamer overlays are used.

```
\documentclass{beamer}

\usepackage[most]{tcolorbox}
\NewTColorBox{quack}{ d<> }{
  alt=<#1>{}{beamer hidden},
}

\begin{document}
\begin{frame}
\begin{quack}<2->
content...
\end{quack}
\end{frame}
\end{document}
```

---

I had to improvise a bit with the doc. If I would add `style, no default, initially unset` as last argument of the `docTcbKey` environment, it would not fit in the line, so I added them in the environment body instead. Is there a better solution?