### PR TITLE
Add missing counter marks in docs

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox.doc.breakable.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.breakable.tex
@@ -140,7 +140,7 @@ parameters. The differences are:
   breakable. It depends on the skin how the breaking looks like.
   If you do not know better, use \refKey{/tcb/enhanced} for breaking a box.
   The parts of the \emph{break sequence} are numbered
-  by the counter |tcbbreakpart|.
+  by the counter \docCounter{tcbbreakpart}.
   \begin{itemize}
   \item\docValue{false}: Sets the |tcolorbox| to be unbreakable.
   \item\docValue{true}: Breaks the |tcolorbox| from one page to another.

--- a/doc/latex/tcolorbox/tcolorbox.doc.coreoptions.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.coreoptions.tex
@@ -3928,8 +3928,8 @@ et malesuada fames ac turpis egestas. \tcbox{Mauris ut leo.}
 \clearpage
 \subsection{Layered Boxes and Every Box Settings}\label{subsec:everybox}
 A |tcolorbox| may contain another |tcolorbox| and so on. The package
-takes track of the nesting level using a counter |tcblayer|. Counter values
-may be used for doing some fancy things, but you should never change
+takes track of the nesting level using a counter \docCounter{tcblayer}. Counter
+values may be used for doing some fancy things, but you should never change
 the counter value yourself.
 
 The package takes special care for the first four layers or nesting levels,


### PR DESCRIPTION
Searching for `\newcounter` in package implementation, these are the only two public counters that are not marked as counter in docs.

```
$ rg -F '\newcounter' tex
tex/latex/tcolorbox/tcblistingscore.code.tex
273:\newcounter{tcblisting}

tex/latex/tcolorbox/tcbraster.code.tex
22:\newcounter{tcbrastercolumn}
23:\newcounter{tcbrasterrow}
24:\newcounter{tcbrasternum}
25:\newcounter{tcbraster}

tex/latex/tcolorbox/tcolorbox.sty
55:\newcounter{tcbbreakpart}
56:\newcounter{tcblayer}
57:\newcounter{tcolorbox@number}
2304:  \newcounter{tcb@cnt@#1}%
```

<sub>(`rg` is a replacement of `grep` provided by https://github.com/BurntSushi/ripgrep.)</sub>