### PR TITLE
Drop unneeded tikz loading in doc examples

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox-example.tex
+++ b/doc/latex/tcolorbox/tcolorbox-example.tex
@@ -21,7 +21,7 @@
 % arara: pdflatex: { synctex: yes }
 %
 \documentclass{article}
-\usepackage{tikz,lipsum,lmodern}
+\usepackage{lipsum,lmodern}
 \usepackage[most]{tcolorbox}
 
 \begin{document}

--- a/doc/latex/tcolorbox/tcolorbox.doc.coreoptions.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.coreoptions.tex
@@ -2882,7 +2882,7 @@ are drawn by the codes given with
 \par\bigskip
 }}
 % Preamble:
-%\usepackage{tikz,lipsum}
+%\usepackage{lipsum}
 %\tcbuselibrary{skins,breakable}
 %\newcounter{example}
 \colorlet{colexam}{red!75!black}

--- a/doc/latex/tcolorbox/tcolorbox.doc.skincatalog.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.skincatalog.tex
@@ -1397,7 +1397,7 @@ are drawn by the codes given by
 \par\bigskip
 }}
 % Preamble:
-%\usepackage{tikz,lipsum}
+%\usepackage{lipsum}
 %\tcbuselibrary{skins,breakable}
 \tikzset{coltria/.style={fill=red!15!white}}
 


### PR DESCRIPTION
Follow-up to #315, but also account for the cases which load multiple packages using one `\usepackage`.

The case `\RequirePackage{tikz}` found in `tcolorbox.doc.s_main.sty` is not cleaned up because it's followed by `\usetikzlibrary` lines.

```
$ rg --no-heading '\\(usep|RequireP)ackage' doc | rg 'tikz'
doc/latex/tcolorbox/tcolorbox.doc.s_main.sty:\RequirePackage{tikz}
```