### PR TITLE
Minor doc polishment

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox.doc.documentation.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.documentation.tex
@@ -12,7 +12,7 @@ Denis Bitouz\'e, Muzimuzhi, and many others provided very valuable input for thi
 
 The library is loaded by a package option or inside the preamble by:
 \begin{dispListing}
-  \tcbuselibrary{documentation}
+\tcbuselibrary{documentation}
 \end{dispListing}
 This also loads
 the library \mylib{skins}, see \Vref{sec:skins},
@@ -44,13 +44,13 @@ In combination with DocStrip, \refKey{/tcb/verbatim ignore percent} may be helpf
 
 For UTF-8 support load (ignore this when using Xe\LaTeX):
 \begin{dispListing}
-  \tcbuselibrary{listingsutf8,documentation}
+\tcbuselibrary{listingsutf8,documentation}
 \end{dispListing}
 
 For \refPkg{minted} \cite{poore:minted} support, load:
 \begin{dispListing}
-  \tcbuselibrary{documentation,minted}
-  \tcbset{listing engine=minted}
+\tcbuselibrary{documentation,minted}
+\tcbset{listing engine=minted}
 \end{dispListing}
 
 

--- a/doc/latex/tcolorbox/tcolorbox.doc.magazine.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.magazine.tex
@@ -130,7 +130,7 @@ registers.
   apply the stored boxes, there is no advantage in using \refCom{boxarrayclear}.
 \begin{dispListing}
 \boxarrayclear            % clears `default'
-\boxarrayclear{myarray}   % clears `myarray'
+\boxarrayclear[myarray]   % clears `myarray'
 \end{dispListing}
 \end{docCommand}
 

--- a/doc/latex/tcolorbox/tcolorbox.doc.magazine.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.magazine.tex
@@ -69,7 +69,7 @@ Ulrike Fischer and Steven B.~Segletes.
 
 The library is loaded by a package option or inside the preamble by:
 \begin{dispListing}
-  \tcbuselibrary{magazine}
+\tcbuselibrary{magazine}
 \end{dispListing}
 This also loads the library \mylib{breakable}, see \zvref[S]{sec:breakable}.
 


### PR DESCRIPTION
Most `\tcbuselibrary{<library>}` examples shown at the start of some `<library>` doc is unindented, so I dropped those indents found in two libraries.

Also fixed the syntax of `\boxarrayclear`. It takes an optional argument, delimited by square brackets.