### PR TITLE
Polish docs, `s/\LaTeX3 argument/argument/g` and more

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox.doc.coremacros.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.coremacros.tex
@@ -232,7 +232,7 @@ numbered title and options.
   Creates a new environment \meta{name} based on \refEnv{tcolorbox}.\\
   Basically, \refCom{NewTColorBox} operates like |\NewDocumentEnvironment|. This means,
   the new environment \meta{name} is constructed with the
-  given \LaTeX3 argument \meta{specification} following \cite{latexproject:usrguide}.
+  given argument \meta{specification} following \cite{latexproject:usrguide}.
   An error is issued if an environment with \meta{name} has already been defined.
   The \meta{options} are given to the underlying \refEnv{tcolorbox}.\\
   Note that \refKey{/tcb/savedelimiter} is set to the given \meta{name}
@@ -294,7 +294,7 @@ This is a tcolorbox.
   In contrast to \refCom{NewTColorBox}, also the \meta{content} of the |tcolorbox| is specified.\\
   Basically, \refCom{NewTotalTColorBox} operates like |\NewDocumentCommand|. This means,
   the new command \texttt{\textbackslash}\meta{name} is constructed with the given
-  \LaTeX3 argument \meta{specification} following \cite{latexproject:usrguide}.
+  argument \meta{specification} following \cite{latexproject:usrguide}.
   An error is issued if \texttt{\textbackslash}\meta{name} has already been defined.
   The \meta{options} are given to the underlying \refEnv{tcolorbox} which is filled with
   the specified \meta{content}.\\
@@ -410,7 +410,7 @@ The \xmybox[green]{quick} brown \xmybox{fox} \xmybox[blue]{jumps} over the
   Creates a new command \texttt{\textbackslash}\meta{name} based on \refCom{tcbox}.
   Basically, \refCom{NewTCBox} operates like |\NewDocumentCommand|. This means,
   the new command \texttt{\textbackslash}\meta{name} is constructed with the given
-  \LaTeX3 argument \meta{specification} following \cite{latexproject:usrguide}.
+  argument \meta{specification} following \cite{latexproject:usrguide}.
   Additional to the argument \meta{specification}, there is an
   automatic last (mandatory) argument of \texttt{\textbackslash}\meta{name} which takes the box content.
   Therefore, \texttt{\textbackslash}\meta{name} may have up to 10 arguments in sum.
@@ -464,7 +464,7 @@ The \xmybox[green]{quick} brown \xmybox{fox} \xmybox[blue]{jumps} over the
   In contrast to \refCom{NewTCBox}, also the \meta{content} of the |tcbox| is specified.\\
   Basically, \refCom{NewTotalTCBox} operates like |\NewDocumentCommand|. This means,
   the new command \texttt{\textbackslash}\meta{name} is constructed with the
-  given \LaTeX3 argument \meta{specification} following \cite{latexproject:usrguide}.
+  given argument \meta{specification} following \cite{latexproject:usrguide}.
   An error is issued if \texttt{\textbackslash}\meta{name} has already been defined.
   The \meta{options} are given to the underlying \refCom{tcbox} which is filled with
   the specified \meta{content}.\\

--- a/doc/latex/tcolorbox/tcolorbox.doc.fitting.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.fitting.tex
@@ -146,7 +146,7 @@ The library is loaded by a package option or inside the preamble by:
   Creates a new command \texttt{\textbackslash}\meta{name} based on \refCom{tcboxfit}.
   Basically, \refCom{NewTCBoxFit} operates like |\NewDocumentCommand|. This means,
   the new command \texttt{\textbackslash}\meta{name} is constructed with the given
-  \LaTeX3 argument \meta{specification} following \cite{latexproject:usrguide}.
+  argument \meta{specification} following \cite{latexproject:usrguide}.
   An error is issued if \texttt{\textbackslash}\meta{name} has already been defined.
   The \meta{options} are given to the underlying \refCom{tcboxfit}.\\
   Note that \refKey{/tcb/savedelimiter} is set to the given \meta{name}
@@ -194,7 +194,7 @@ The library is loaded by a package option or inside the preamble by:
   In contrast to \refCom{NewTCBoxFit}, also the \meta{content} of the |tcboxfit| is specified.\\
   Basically, \refCom{NewTotalTCBoxFit} operates like |\NewDocumentCommand|. This means,
   the new command \texttt{\textbackslash}\meta{name} is constructed with the given
-  \LaTeX3 argument \meta{specification} following \cite{latexproject:usrguide}.
+  argument \meta{specification} following \cite{latexproject:usrguide}.
   An error is issued if \texttt{\textbackslash}\meta{name} has already been defined.
   The \meta{options} are given to the underlying \refCom{tcboxfit} which is filled with
   the specified \meta{content}.\\

--- a/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
@@ -291,7 +291,7 @@ This is my \LaTeX\ box.
   Creates a new environment \meta{name} based on \refEnv{tcblisting}.\\
   Basically, \refCom{NewTCBListing} operates like |\NewDocumentEnvironment|. This means,
   the new environment \meta{name} is constructed with the
-  given \LaTeX3 argument \meta{specification} following \cite{latexproject:usrguide}.
+  given argument \meta{specification} following \cite{latexproject:usrguide}.
   An error is issued if \meta{name} has already been defined.
   The \meta{options} are given to the underlying \refEnv{tcblisting}.\\
   Note that \refKey{/tcb/savedelimiter} is set to the given \meta{name}
@@ -439,7 +439,7 @@ Note that the following code uses \verb+!O{}+ now.
   Creates a new command \texttt{\textbackslash}\meta{name} based on \refCom{tcbinputlisting}.
   Basically, \refCom{NewTCBInputListing} operates like |\NewDocumentCommand|. This means,
   the new command \texttt{\textbackslash}\meta{name} is constructed with the
-  given \LaTeX3 argument \meta{specification} following \cite{latexproject:usrguide}.
+  given argument \meta{specification} following \cite{latexproject:usrguide}.
   An error is issued if \texttt{\textbackslash}\meta{name} has already been defined.
   The \meta{options} are given to the underlying \refCom{tcbinputlisting}.\\
   The \meta{init options} allow setting up automatic numbering,

--- a/doc/latex/tcolorbox/tcolorbox.doc.skins.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.skins.tex
@@ -2761,7 +2761,7 @@ the \refSkin{standard} skin is used, all hyper option are silently ignored.
 \end{marker}
 
 \begin{docTcbKey}[][doc new=2017-02-03]{hyperref}{=\meta{marker}}{no default, initially unset}
-  The whole \textit{frame} of a |tcolorbox| is make an active hyperlink for a
+  The whole \textit{frame} of a |tcolorbox| is made an active hyperlink for a
   \meta{marker} which was given by |\label| or \refKey{/tcb/label} or \refKey{/tcb/phantomlabel}.
   Such, the |tcolorbox| is made a clickable button (depending on the previewer).
   \begin{dispExample*}{sbs,lefthand ratio=0.7}
@@ -2804,7 +2804,7 @@ Jump to the heading of Section~\ref*{sec:skins}
 \end{docTcbKey}
 
 \begin{docTcbKey}[][doc new=2017-02-03]{hyperlink}{=\meta{marker}}{no default, initially unset}
-  The whole \textit{frame} of a |tcolorbox| is make an active hyperlink for a
+  The whole \textit{frame} of a |tcolorbox| is made an active hyperlink for a
   \meta{marker} which was given by |\hypertarget| or \refKey{/tcb/hypertarget}.
   Such, the |tcolorbox| is made a clickable button (depending on the previewer).
   \begin{dispExample*}{sbs,lefthand ratio=0.7}
@@ -2841,7 +2841,7 @@ Click me to jump to Box A.
 \end{docTcbKey}
 
 \begin{docTcbKey}[][doc new=2017-02-03]{hyperurl}{=\meta{url}}{no default, initially unset}
-  The whole \textit{frame} of a |tcolorbox| is make an active hyperlink for an
+  The whole \textit{frame} of a |tcolorbox| is made an active hyperlink for a
   \meta{url} in the same manner as using |\href| or |\url|.
   Such, the |tcolorbox| is made a clickable button (depending on the previewer).
   \begin{dispExample*}{sbs,lefthand ratio=0.7}
@@ -3048,5 +3048,3 @@ This box looks like a box provided by the \texttt{beamer} class.
 \end{mybeamer}
 \end{dispExample*}
 \end{docTcbKey}
-
-


### PR DESCRIPTION
As the `xparse` is bundled into the LaTeX kernel, it's not necessary and even confusing to call the `<specification>` in syntaxes like
```tex
\NewTColorBox[⟨init options⟩]{⟨name⟩}{⟨specification⟩}{⟨options⟩}
```
"LaTeX3 argument `<specification>`".

I suggest to drop the word "LaTeX3".

As the `usrguide` is always cited along with the phrase, no ambiguity would be introduced.