### PR TITLE
Correct doc typos

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox.doc.poster.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.poster.tex
@@ -20,7 +20,7 @@ depending on the actual project.
   which gets broken into lines (and paragraphs) and the lines are broken
   into pages. \mylib{raster} shapes the boxes to convenient sizes to fill
   lines and pages in a pleasant way.
-\item The \mylib{tcbposter} library supports a quite free placement of
+\item The \mylib{poster} library supports a quite free placement of
   boxes inside a page.
   Basically, boxes are placed like |node|s are placed inside a |tikzpicture|.
   In contrast to \mylib{raster}, this is a \emph{single} page


### PR DESCRIPTION
`s/\mylib{tcbposter}/\mylib{poster}/`

All other uses of `\mylib{<library>}` are valid:

```
$ rg -oI '\\mylib\{.*?\}' | cat | sort | uniq
\mylib{breakable}
\mylib{documentation}
\mylib{external}
\mylib{fitting}
\mylib{hooks}
\mylib{listingsutf8}
\mylib{listings}
\mylib{magazine}
\mylib{minted}
\mylib{poster}
\mylib{raster}
\mylib{skins}
\mylib{theorems}
\mylib{vignette}
\mylib{xparse}
```