### PR TITLE
Apply `\refPkg`

### DIFF
--- a/doc/latex/tcolorbox/tcolorbox.doc.beamer.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.beamer.tex
@@ -3,8 +3,8 @@
 \clearpage
 \section{Beamer Support}\label{sec:beamer}%
 \tcbset{external/prefix=external/beamer_}%
-The \mylib{skins} library adds some supporting options for the |beamer| package
-\cite{tantau:beamer}.
+The \mylib{skins} library adds some supporting options for the \refPkg{beamer}
+package \cite{tantau:beamer}.
 For the following options, the \mylib{skins} library has to be loaded
 by a package option or inside the preamble by:
 \begin{dispListing}

--- a/doc/latex/tcolorbox/tcolorbox.doc.coreoptions.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.coreoptions.tex
@@ -6,7 +6,7 @@
 For the \meta{options} in \refEnv{tcolorbox} respectively \refCom{tcbset}
 the following |pgf| keys can be applied%
 \footnote{Strictly speaking, they are \texttt{pgfkeys} keys.
-  The \texttt{pgfkeys} package is auto-loaded by \texttt{pgf} and is
+  The \refPkg{pgfkeys} package is auto-loaded by \refPkg{pgf} and is
   documented in \cite[Part~VII]{tantau:tikz_and_pgf}.}.
 The key tree path |/tcb/| is not to
 be used inside these macros. It is easy to add your own style keys using
@@ -2800,8 +2800,8 @@ Common special cases are \emph{watermarks} which are implemented using overlays.
 See Subsection \ref{subsec:watermarks} from page \pageref{subsec:watermarks} if
 you want to add \emph{watermarks}.
 \begin{marker}
-If you use the core package only, the \meta{graphical code} has to be |pgf| code
-and there is not much assistance for positioning.
+If you use the core package only, the \meta{graphical code} has to be
+\refPkg{pgf} code and there is not much assistance for positioning.
 Therefore, the usage of the \refKey{/tcb/enhanced} mode from the library skins
 is recommended which allows \tikzname\ code and gives access to
 \refKey{/tcb/geometry nodes} for positioning.
@@ -3024,8 +3024,9 @@ are drawn by the codes given with
 \begin{docTcbKey}{float*}{\colOpt{=\meta{values}}}{default from \texttt{floatplacement}}
   Identical to \refKey{/tcb/float}, but for wide boxes spanning the whole page
   width of two column documents or in conjunction with the packages
-  |multicol| or |paracol|. Note that you have to set |width=\textwidth|
-  additionally, if the box should span the whole page width in these cases!
+  \refPkg{multicol} or \refPkg{paracol}. Note that you have to set
+  |width=\textwidth| additionally, if the box should span the whole page width
+  in these cases!
 \begin{dispListing}
 \begin{tcolorbox}[float*=b, title=Floating box from |float*|,width=\textwidth,
     enhanced,watermark text={I'm also floating}]
@@ -4566,7 +4567,7 @@ to see the bookmark.
   Adds an \meta{entry} to an index with a specific \meta{name}.
   This is a shortcut for
   setting |\index|\oarg{name}\marg{entry} to \refKey{/tcb/phantom}.
-  An index extension package like |imakeidx| has to be loaded to use
+  An index extension package like \refPkg{imakeidx} has to be loaded to use
   this option key.
 \end{docTcbKey}
 
@@ -4681,7 +4682,7 @@ the correct page test is applied.
 But for \refKey{/tcb/breakable} boxes, \refCom{tcbifoddpage}
 will always give the result for the page of the \emph{first} box inside
 the box \textbf{content text}. If needed, the methods from the packages
-|changepage| or |ifoddpage| could be used here.
+\refPkg{changepage} or \refPkg{ifoddpage} could be used here.
 %To mention it again, for overlays, watermarks, etc, \refCom{tcbifoddpage} gives
 %the correct page test.
 
@@ -4850,7 +4851,7 @@ This is a \textbf{tcolorbox}.
       doc parameter   = {=\marg{token list}\marg{false options}},
     }
   }
-  Wraps the |\tl_if_blank:n(TF)| command(s) of \textsf{expl3} for option setting.
+  Wraps the |\tl_if_blank:n(TF)| command(s) of \refPkg[l3kernel]{expl3} for option setting.
   If the \meta{token list} consists only of blank spaces or is entirely empty, the \meta{true options} are set.
   Otherwise, the \meta{false options} are set.
 \begin{dispExample}
@@ -4883,7 +4884,7 @@ This is a tcolorbox.
       doc parameter   = {=\marg{token list}\marg{false options}},
     }
   }
-  Wraps the |\tl_if_empty:n(TF)| command(s) of \textsf{expl3} for option setting.
+  Wraps the |\tl_if_empty:n(TF)| command(s) of \refPkg[l3kernel]{expl3} for option setting.
   If the \meta{token list} is entirely empty, the \meta{true options} are set.
   Otherwise, the \meta{false options} are set.
 \begin{dispExample}

--- a/doc/latex/tcolorbox/tcolorbox.doc.documentation.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.documentation.tex
@@ -440,7 +440,7 @@ The color \docColor{foocolor} is available.
 
 
 \begin{docCommand}{cs}{\marg{name}}
-  Macro from |ltxdoc| \cite{carlisle:ltxdoc} to typeset a command word \meta{name}
+  Macro from \refPkg{ltxdoc} \cite{carlisle:ltxdoc} to typeset a command word \meta{name}
   where the backslash is prefixed. The library overwrites the original macro.
 \begin{dispExample}
 This is a \cs{foocommand}.
@@ -448,7 +448,7 @@ This is a \cs{foocommand}.
 \end{docCommand}
 
 \begin{docCommand}{meta}{\marg{text}}
-  Macro from |doc| \cite{mittelbach:doc} to typeset a meta \meta{text}.
+  Macro from \refPkg{doc} \cite{mittelbach:doc} to typeset a meta \meta{text}.
   The library overwrites the original macro.
 \begin{dispExample}
 This is a \meta{text}.
@@ -457,7 +457,7 @@ This is a \meta{text}.
 
 
 \begin{docCommand}{marg}{\marg{text}}
-  Macro from |ltxdoc| \cite{carlisle:ltxdoc} to typeset a \meta{text} with
+  Macro from \refPkg{ltxdoc} \cite{carlisle:ltxdoc} to typeset a \meta{text} with
   curly brackets as a mandatory argument. The library overwrites the original macro.
 \begin{dispExample}
 This is a mandatory \marg{argument}.
@@ -465,7 +465,7 @@ This is a mandatory \marg{argument}.
 \end{docCommand}
 
 \begin{docCommand}{oarg}{\marg{text}}
-  Macro from |ltxdoc| \cite{carlisle:ltxdoc} to typeset a \meta{text} with
+  Macro from \refPkg{ltxdoc} \cite{carlisle:ltxdoc} to typeset a \meta{text} with
   square brackets as an optional argument. The library overwrites the original macro.
 \begin{dispExample}
 This is an optional \oarg{argument}.
@@ -475,8 +475,8 @@ This is an optional \oarg{argument}.
 \clearpage
 
 \begin{docCommand}[doc new={2025-05-28}]{pbarg}{\marg{text}}
-  Renamed macro from the \cite{tantau:beamer} documentation to typeset a \meta{text} with
-  pointed brackets as a mandatory argument.
+  Renamed macro from the \refPkg{beamer} \cite{tantau:beamer} documentation to
+  typeset a \meta{text} with pointed brackets as a mandatory argument.
 \begin{dispExample}
 This is a beamer \pbarg{argument}.
 \end{dispExample}
@@ -696,7 +696,7 @@ We have created \refPathOperation*{fooop} as an example.
 \begin{docCommand}[doc updated=2020-02-11]{refAux}{\marg{name}}
   References some auxiliary environment, key, value, or color.
   The \meta{name} is colored according to \refKey{/tcb/color hyperlink},
-  if |hyperref| colorlinks are set, but there is no real link.
+  if \refPkg{hyperref} colorlinks are set, but there is no real link.
 \begin{dispExample}
 Some pages back, one can see \refAux{/foo/footitle} as an example.
 \end{dispExample}
@@ -706,7 +706,7 @@ Some pages back, one can see \refAux{/foo/footitle} as an example.
   References some auxiliary macro \meta{name} where \meta{name} is
   written without backslash.
   The \meta{name} is colored according to \refKey{/tcb/color hyperlink},
-  if |hyperref| colorlinks are set, but there is no real link.
+  if \refPkg{hyperref} colorlinks are set, but there is no real link.
 \begin{dispExample}
 Some pages back, one can see \refAuxcs{fooaux} as an example.
 \end{dispExample}
@@ -859,9 +859,10 @@ with another note.
   Sets the \meta{key prefix} (root path) of the key to document.
   This prefix is prepended to \refKey{/tcb/doc keypath}, if
   \refKey{/tcb/doc keypath} is not empty.
-  The default |/| setting is intended for |pgfkeys|.
-  For |l3keys|, setting \refKey{/tcb/doc key prefix} to be empty is more
-  appropriate, since their path starts with a module name without |/|.
+  The default |/| setting is intended for \refPkg{pgfkeys}.
+  For \refPkg[l3kernel]{l3keys}, setting \refKey{/tcb/doc key prefix} to be
+  empty is more appropriate, since their path starts with a module name
+  without |/|.
 \begin{dispExample}
 \begin{docKeys}[
     doc no index,  %  no index entries for this example
@@ -895,8 +896,8 @@ Sets \meta{macro} as formatter for the text given by
 \refKey{/tcb/doclang/keys} inside the index.
 The \meta{macro} has to take one mandatory
 argument (the language text).
-The intended purpose is to differentiate between different sorts of
-keys, if necessary, e.g.\ between |pgfkeys| and |l3keys|.
+The intended purpose is to differentiate between different sorts of keys,
+if necessary, e.g.\ between \refPkg{pgfkeys} and \refPkg[l3kernel]{l3keys}.
 If these options are used without value, the formatters are reset to
 their standard behavior.
 
@@ -1450,7 +1451,7 @@ Draw your own picture with help of the \refPkg{tikz} package.
   \mbox{\cs{index}\texttt{[\meta{name}]}}, i.e.\ 
   \mbox{\cs{index}\texttt{\textbraceleft\ldots\textbraceright}} is replaced by
   \mbox{\cs{index}\texttt{[\meta{name}]\textbraceleft\ldots\textbraceright}}.
-  This option is intended to be used with |imakeidx| and is
+  This option is intended to be used with \refPkg{imakeidx} and is
   mutually exclusive with \refKey{/tcb/index command}.
 \begin{dispListing}
 \tcbset{index command name=mydoc}
@@ -1463,10 +1464,11 @@ Draw your own picture with help of the \refPkg{tikz} package.
   Determines the basic \meta{format} of the generated index.
   Feasible values are:
   \begin{itemize}
-  \item\docValue{pgfsection}: The index is formatted like in the |pgf| documentation (as a section).
-  \item\docValue{pgfchapter}: The index is formatted like in the |pgf| documentation (as a chapter).
+  \item\docValue{pgfsection}: The index is formatted like in the \refPkg{pgf} documentation (as a section).
+  \item\docValue{pgfchapter}: The index is formatted like in the \refPkg{pgf} documentation (as a chapter).
   \item\docValue{pgf}: Alias for |pgfsection|.
-  \item\docValue{doc}: The index is assumed to be formatted by |doc| or |ltxdoc|. The usage of |makeindex|
+  \item\docValue{doc}: The index is assumed to be formatted by \refPkg{doc} or
+    \refPkg{ltxdoc}. The usage of \refPkg{makeindex}
     with |-s gind.ist| is assumed. The package \refPkg{hypdoc} has to be loaded
     \emph{before} |tcolorbox|. Only a limited set of customizations will
     work! This option cannot be unset when used!
@@ -1489,7 +1491,7 @@ Draw your own picture with help of the \refPkg{tikz} package.
 \end{docTcbKey}
 
 \begin{docTcbKey}{index default settings}{}{style, no value}
-  Sets the |makeindex| default values for
+  Sets the \refPkg{makeindex} default values for
   \refKey{/tcb/index actual},
   \refKey{/tcb/index quote}, and
   \refKey{/tcb/index level}.
@@ -1497,7 +1499,7 @@ Draw your own picture with help of the \refPkg{tikz} package.
 
 
 \begin{docTcbKey}{index german settings}{}{style, no value}
-  Sets the |makeindex| values recommended for German language texts.
+  Sets the \refPkg{makeindex} values recommended for German language texts.
   This is identical to setting the following:
 \begin{dispListing}
 \tcbset{index actual={=},index quote={!},index level={>}}

--- a/doc/latex/tcolorbox/tcolorbox.doc.filling.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.filling.tex
@@ -29,7 +29,7 @@ with future updates of \tikzname.
 \end{marker}
 
 \begin{docCommand}[doc new=2014-05-05]{tcbpatcharcangular}{}
-The \tikzname\ package provides a nice |rounded corners| option to replace
+The \refPkg{tikz} package provides a nice |rounded corners| option to replace
 all corners by little arcs. |\tcbpatcharcangular| is a patch which
 straightens the arcs. To say it more prosaic, the little arcs are replaced
 by little straight lines.

--- a/doc/latex/tcolorbox/tcolorbox.doc.initoptions.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.initoptions.tex
@@ -22,7 +22,7 @@ Typically, these options may generate counters and alike.
 It is \textbf{strongly} recommended that you use initialization options inside
 the preamble only. Otherwise, you may get trouble when using \LaTeX's |\include| features.
 Also, it is recommended to generate new environments and commands with these
-options \emph{after} |hyperref| is loaded to avoid warnings about
+options \emph{after} \refPkg{hyperref} is loaded to avoid warnings about
 \emph{duplicate identifiers}.
 \end{marker}
 
@@ -134,7 +134,7 @@ be used to overrule a previous option.
 
 
 \begin{newTcbKey}[][doc new=2019-10-18]{reset counter on overlays}{\colOpt{=true\textbar false}}{default |true|, initially |false|}
-For |beamer| slides, this invokes the |\resetcounteronoverlays| command
+For \refPkg{beamer} slides, this invokes the |\resetcounteronoverlays| command
 for the box counter. The counter is automatically reset on subsequent
 overlay slides of a frame.
 Thereby, the counter will be the same on all slides of every frame.

--- a/doc/latex/tcolorbox/tcolorbox.doc.intro.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.intro.tex
@@ -48,9 +48,10 @@ for some hints. The short story is: you have to install not only
 
 \subsection{Loading the Package}
 The base package |tcolorbox| loads the packages
-|tikz| \cite{tantau:tikz_and_pgf}, |verbatim| \cite{schoepf:verbatim},
-|etoolbox| \cite{lehmann:etoolbox},
-and |environ| \cite{robertson:2014a}.
+\refPkg{tikz} \cite{tantau:tikz_and_pgf},
+\refPkg{verbatim} \cite{schoepf:verbatim},
+\refPkg{etoolbox} \cite{lehmann:etoolbox},
+and \refPkg{environ} \cite{robertson:2014a}.
 |tcolorbox| itself is loaded in the usual manner in the preamble:
 \begin{dispListing}
 \usepackage{tcolorbox}
@@ -101,7 +102,7 @@ The following keys are used inside |\tcbuselibrary| respectively
 
 \begin{docTcbKey}[library]{listingsutf8}{}{\mylib{listingsutf8}}
   Loads the packages \refPkg{listings} \cite{hoffmann:listings} and
-  |listingsutf8| \cite{oberdiek:listingsutf8} for UTF-8 support.
+  \refPkg{listingsutf8} \cite{oberdiek:listingsutf8} for UTF-8 support.
   This is a variant of the library \mylib{listings}
   and is described in \zvref{sec:listings}.
 \end{docTcbKey}

--- a/doc/latex/tcolorbox/tcolorbox.doc.poster.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.poster.tex
@@ -306,7 +306,7 @@ The \meta{option list} can contain any |tcolorbox| option.
   It uses \refKey{/tcb/fit basedim} and \refKey{/tcb/fit fontsize macros}
   to redefine |\normalsize| to \meta{length} and all other standard
   font size macros like |\small| and |\large| accordingly.\par
-  This needs a freely scalable font family like |lmodern| to work.
+  This needs a freely scalable font family like \refPkg[lm]{lmodern} to work.
   If \refKey{/tcb/posterset/fontsize} is not applied, there standard
   font size macros are not changed in any way.
 

--- a/doc/latex/tcolorbox/tcolorbox.doc.skincatalog.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.skincatalog.tex
@@ -112,8 +112,8 @@ defined just for this documentation.
 
 \begin{docSkin}{standard}
   This is the standard skin from the core package. All drawing engines
-  are set to type |standard|. The drawing is based on |pgf| commands and
-  does not need the \tikzname\ package.
+  are set to type |standard|. The drawing is based on \refPkg{pgf} commands and
+  does not need the \refPkg{tikz} package.
 \begin{tcolorbox}[skintable=standard]
   \begin{tabbing}
     \refKey{/tcb/interior titled engine}: \=\kill
@@ -977,9 +977,9 @@ Nevertheless, this skin can be applied independently.
 \subsection{Skin Family \enquote{beamer}}
 
 \begin{docSkin}{beamer}
-  This skin resembles boxes known from the |beamer| class and therefore is
-  called \enquote{beamer}. It uses the normal colors from the core package but shades
-  them a little bit.
+  This skin resembles boxes known from the \refPkg{beamer} class and therefore
+  is called \enquote{beamer}. It uses the normal colors from the core package
+  but shades them a little bit.
 \begin{tcolorbox}[skintable=beamer]
   \begin{tabbing}
     \refKey{/tcb/interior titled engine}: \=\kill
@@ -1565,8 +1565,8 @@ you would have used \refKey{/tcb/freelance} before.
 
 \begin{docSkin}{freelance}
   This skin gives full freedom for the appearance of the |tcolorbox|.
-  All drawing engines are set to type |freelance|; they use the \tikzname\ package
-  and compute the \refKey{/tcb/geometry nodes}.
+  All drawing engines are set to type |freelance|; they use the \refPkg{tikz}
+  package and compute the \refKey{/tcb/geometry nodes}.
   %This skin is useful for boxes which should differ much from the normal
   %appearance. Note that this difference has to be programmed by the user.
   %The drawing code can be given

--- a/doc/latex/tcolorbox/tcolorbox.doc.skins.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.skins.tex
@@ -2874,8 +2874,8 @@ View CTAN with a browser.
 
 
 \begin{docTcbKey}[][doc new=2017-02-03]{hyperurl*}{=\marg{options}\marg{url}}{no default, initially unset}
-  Identical to \refKey{/tcb/hyperurl}, but additional |hyperref| \cite{rahtz:hyperref}
-  \meta{options} are applied.
+  Identical to \refKey{/tcb/hyperurl}, but additional
+  \refPkg{hyperref} \cite{rahtz:hyperref} \meta{options} are applied.
   \begin{dispExample*}{sbs,lefthand ratio=0.7}
 \begin{tcolorbox}[enhanced,colback=green!50,
   hyperurl*={page=3,pdfnewwindow=true}%

--- a/doc/latex/tcolorbox/tcolorbox.doc.technical.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.technical.tex
@@ -205,10 +205,10 @@ The following code options are applicable for all skins.
 %use engines of type |freelance|.
 %Especially, the skin \refSkin{freelance} supports \emph{all} of them,
 %\refSkin{standard} and \refSkin{enhanced} \emph{none} of them.
-The used \meta{graphical code} can be any |pgf| code. For all skins
+The used \meta{graphical code} can be any \refPkg{pgf} code. For all skins
 with exception of \refSkin{standard}
 and \refSkin{standard jigsaw}, the \meta{graphical code} can also
-be any \tikzname\ code.
+be any \refPkg{tikz} code.
 
 
 \begin{docTcbKey}{frame code}{\colOpt{=\meta{graphical code}}}{code, default from |standard|}

--- a/doc/latex/tcolorbox/tcolorbox.doc.theorems.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.theorems.tex
@@ -158,7 +158,7 @@ To switch off the \texttt{nameref} feature permanently, add
   Creates a \refEnv{tcolorbox} which is fitted to the width of the given
   \meta{mathematical box content}. This box is intended to be applied as
   part of a larger formula and may be used as replacement for the |\boxed|
-  macro of |amsmath|.
+  macro of \refPkg{amsmath}.
 
 \begin{dispExample}
 \begin{equation}
@@ -658,7 +658,8 @@ created by hand or using \refCom{newtcbtheorem}.
 
 
 \begin{marker}
-  The following styles are only tested to work with the original |amsmath| environments.
+  The following styles are only tested to work with the original
+  \refPkg{amsmath} environments.
   If e.g. the |equation| environment is redefined as |gather|, then
   \refKey{/tcb/ams equation} should / could not be used. Obviously, you are encouraged
   to use \refKey{/tcb/ams gather} in this case.

--- a/doc/latex/tcolorbox/tcolorbox.doc.verbatim.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.verbatim.tex
@@ -4,7 +4,7 @@
 \section{Saving and Loading of Verbatim Texts}%
 \tcbset{external/prefix=external/verbatim_}%
 The following macros are slightly modified versions of the original macros
-from the known packages |moreverb| and |verbatim|.
+from the known packages \refPkg{moreverb} and \refPkg{verbatim}.
 They are used implicitly inside of a |tcolorbox| environment,
 but they can be used outside also.
 \enlargethispage*{1.5cm}


### PR DESCRIPTION
This PR applies `\refPkg` on most package names in docs.

- Only applied to the first references in a doc block.
- Not applied to `|xparse|`, to avoid conflicts when solving #341.
- The `\refPkg{<pkg name>}` form is used as long as the corresponding CTAN page exists, even when
  - the `<pkg name>` is redirected by CTAN (e.g. https://ctan.org/pkg/tikz), or
  - `<pkg name>` belongs to a package bundle (e.g. https://ctan.org/pkg/pgfkeys), because such CTAN pages give more specific introduction to the `<pkg name>`.

Not do in this PR: Add references (bib entries and `\cite`s).