### PR TITLE
Restore use of minted v3

### DIFF
--- a/doc/latex/tcolorbox/CHANGELOG.md
+++ b/doc/latex/tcolorbox/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to
 ### Changed
 - Required LaTeX version bumped to 2025-06-01
 - Implementation for numbered boxes is partially rewritten using the L3 API
+- Documentation: 
+    Replace `minted2` with `minted` v3 for production since `minted` v3.8.0 has fixed incompatibility with Python 3.14
+    (https://github.com/gpoore/minted/issues/463)
 
 ### Deprecated
 

--- a/doc/latex/tcolorbox/tcolorbox-example-poster.tex
+++ b/doc/latex/tcolorbox/tcolorbox-example-poster.tex
@@ -27,7 +27,7 @@
 \usepackage{enumerate}
 
 \usepackage[poster]{tcolorbox}
-\usepackage{minted2}%   minted is currently broken
+\usepackage{minted}
 \tcbuselibrary{minted} % <- replace by \tcbuselibrary{listings}, if minted does not work for you
 
 \pagestyle{empty}

--- a/doc/latex/tcolorbox/tcolorbox-tutorial-poster.tex
+++ b/doc/latex/tcolorbox/tcolorbox-tutorial-poster.tex
@@ -28,7 +28,7 @@
 \usepackage{enumerate}
 
 \usepackage[poster]{tcolorbox}
-\usepackage{minted2}%   minted is currently broken
+\usepackage{minted}
 \tcbuselibrary{minted} % <- replace by \tcbuselibrary{listings}, if minted does not work for you
 
 \pagestyle{empty}
@@ -123,7 +123,7 @@ Also, some more packages are loaded for the future poster content.
 \usepackage{lmodern}
 \usepackage{enumerate}
 \usepackage[poster]{tcolorbox}
-\usepackage{minted2}%   minted is currently broken
+\usepackage{minted}
 \tcbuselibrary{minted} % <- replace by \tcbuselibrary{listings}, if minted does not work for you
 \pagestyle{empty}
 

--- a/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
+++ b/doc/latex/tcolorbox/tcolorbox.doc.listings.tex
@@ -76,7 +76,7 @@ This also loads the package \refPkg{minted} \cite{poore:minted}.
 \begin{marker}
 To use the legacy version v2.9 of \refPkg{minted}, write
 \begin{dispListing}
-\usepackage{minted2}
+\usepackage{minted}
 \end{dispListing}
 \emph{before} loading the library!
 \end{marker}

--- a/doc/latex/tcolorbox/tcolorbox.doc.s_main.sty
+++ b/doc/latex/tcolorbox/tcolorbox.doc.s_main.sty
@@ -30,7 +30,7 @@
 \providecommand{\tcbpkgprefix}{}
 \RequirePackage{\tcbpkgprefix tcolorbox}
 
-\usepackage{minted2}%   minted is currently broken
+\usepackage{minted}
 \tcbuselibrary{most,documentation}
 
 \tcbifexternal{}{%


### PR DESCRIPTION
`minted` v3.8.0 2026-03-03 (more specifically the bundled [`latexminted` v0.7.0](https://github.com/gpoore/minted/releases/tag/python%2Fv0.7.0)) has fixed incompatibility with Python 3.14.

@T-F-S You other packages may need similar changes. (Just saw the CTAN annotation for `incgraph` v1.4.0 2026-03-04, which contained a `minted` -> `minted2` changelog entry.)