### PR TITLE
Breakable boxes corrupt DVI color stack on XeTeX

### DIFF
--- a/tex/latex/tcolorbox/tcbbreakable.code.tex
+++ b/tex/latex/tcolorbox/tcbbreakable.code.tex
@@ -86,8 +86,10 @@
   \let\tcbbreak\tcb@@break%
   \iftcb@usecolorstack%
     \pdfcolSwitchStack{tcb@breakable}%
+    \color@begingroup%
+  \else%
+    \begingroup%
   \fi%
-  \color@begingroup%
   \textwidth\hsize%
   \columnwidth\hsize%
   \csname tcb@parboxrestore@\kvtcb@parbox\endcsname%
@@ -113,7 +115,7 @@
     \unvbox\@mpfootins%
   \fi%
   \@minipagefalse%
-  \color@endgroup}
+  \iftcb@usecolorstack\color@endgroup\else\endgroup\fi}
 
 % remaining height
 \def\tcb@comp@h@page{%


### PR DESCRIPTION
XeTeX does not have `\pdfcolorstack`, so `\color@begingroup` / `\color@endgroup` in `tcb@vbox` / `endtcb@vbox` end up emitting DVI color specials directly into the box content. When the breakable mechanism later splits that box with `\vsplit`, those pushes and pops get separated across pages. Over time this leaks entries and eventually overflows dvipdfmx's color stack, breaking colors in the document.

IMO the fix is to avoid `\color@begingroup` on the non-colorstack path. A normal TeX group is enough because the draw hooks already scope colors correctly.